### PR TITLE
Add ShipmentLine nested model

### DIFF
--- a/lib/snap.rb
+++ b/lib/snap.rb
@@ -5,6 +5,8 @@ require 'snap/version'
 require 'snap/client'
 
 require 'snap/api/shipments'
+
+require 'snap/models/shipment_line'
 require 'snap/models/shipment'
 
 # Top level module for the Snap gem.

--- a/lib/snap/models/shipment.rb
+++ b/lib/snap/models/shipment.rb
@@ -3,6 +3,7 @@ module Snap
     # A representation of a Snap Shipment object.
     class Shipment < Hashie::Dash
       include Hashie::Extensions::IndifferentAccess
+      include Hashie::Extensions::Dash::Coercion
 
       property :ShipmentId, required: true
       property :BizId
@@ -85,7 +86,7 @@ module Snap
       property :OverdueInd
       property :Stage
       property :MaintInd
-      property :ShipmentLines
+      property :ShipmentLines, coerce: Array[Models::ShipmentLine]
       property :ShipAddress
       property :ShipContacts
       property :ShipmentDespatch

--- a/lib/snap/models/shipment_line.rb
+++ b/lib/snap/models/shipment_line.rb
@@ -1,0 +1,45 @@
+module Snap
+  module Models
+    # A representation of a single ShipmentLine.
+    class ShipmentLine < Hashie::Dash
+      include Hashie::Extensions::IndifferentAccess
+
+      property :ShipmentId, required: true
+      property :Line
+      property :Level
+      property :SKUId, required: true
+      property :BizSKU
+      property :LineOwner
+      property :LineStockStatus
+      property :QtyOrdered, required: true
+      property :QtyRequired, required: true
+      property :QtyAllocated
+      property :QtyTasked
+      property :UnitOfMeasure, required: true
+      property :QtyPicked
+      property :QtyShipped
+      property :QtyDelivered
+      property :QtyDueOut
+      property :Price, required: true
+      property :Discount
+      property :TaxRate
+      property :SOLineId
+      property :ReturnReason
+      property :QC
+      property :Shortage
+      property :Variance
+      property :BOInd
+      property :ConsignmentId
+      property :PickGroupId
+      property :SiteId
+      property :Warehouse
+      property :BizId
+      property :OwnerId
+      property :StockStatus
+      property :DateShipment
+      property :AttachmentInd
+      property :SpecialConditionInd
+      property :Stage
+    end
+  end
+end


### PR DESCRIPTION
This adds coercion and nested models. The motivation here being that
outside of this gem we should accept a single properly structured hash,
and that hash can contain many models and will need to in order to
provide all the correct data in order to do something like create a
shipment inside of Snap. To try and easy the use of developing and using
this gem, on our side we will automatically look for specific nested
models and initialize them.