### PR TITLE
Handle Common Bad Requests

### DIFF
--- a/lib/snap/client.rb
+++ b/lib/snap/client.rb
@@ -6,7 +6,24 @@ module Snap
     def client
       base_uri Snap.config.endpoint
       basic_auth(Snap.config.username, Snap.config.password)
+      raise_on 500..599
       self
+    end
+
+    def get(*args, &block)
+      parse_response do
+        super(*args, &block)
+      end
+    end
+
+    def post(*args, &block)
+      parse_response do
+        super(*args, &block)
+      end
+    end
+
+    def parse_response
+      response = yield
     end
   end
 end


### PR DESCRIPTION
Putting this on hold until we have more api classes, one that comes to mind is Order Stage. 

We should be doing everything we can to prevent bad requests from going out, but because Snap is stateful there are a certain class of bad requests we could not know were bad before Snap tells us. 

We should identify and raise the proper error for these. 
