### PR TITLE
Add errors!

### DIFF
--- a/lib/snap.rb
+++ b/lib/snap.rb
@@ -6,6 +6,8 @@ require 'snap/version'
 require 'snap/client'
 require 'snap/response'
 
+require 'snap/api/errors/order_stage_error'
+
 require 'snap/api/outbound'
 require 'snap/api/stock_totals'
 require 'snap/api/shipment_status'

--- a/lib/snap/api/errors/order_stage_error.rb
+++ b/lib/snap/api/errors/order_stage_error.rb
@@ -1,0 +1,8 @@
+module Snap
+  module Api
+    # An order stage error occurs when you attempt to update a shipment that is
+    # in a stage that does not allow updates.
+    class OrderStageError < StandardError
+    end
+  end
+end


### PR DESCRIPTION
This adds a block to snoop into responses and see if they have
encountered a common error. This is helpful for consumers to control the
flow of the code in certain situations. This error is especially is very
odd to identify. This is also not something we could have prevented by
snooping the request. Snap is stateful and we don't know the state
pre-flight.