### PR TITLE
Fix case expression bug in snoop_for_errors

### DIFF
--- a/lib/snap/client.rb
+++ b/lib/snap/client.rb
@@ -41,12 +41,12 @@ module Snap
     end
 
     def snoop_for_errors(httparty_response)
-      case httparty_response.parsed_response.class
+      case httparty_response.parsed_response.class.to_s
         # Snap can return response bodies in many different formats. How we look
         # for and what errors can occur are dependent on that type. For example
         # 500's mostly return raw html as a string. Pages with lists are an
         # Array. Resource endpoints are typically Hash.
-      when Hash
+      when 'Hash'
         raise Api::OrderStageError, httparty_response if httparty_response.parsed_response.value? 'ORDER_STAGE'
       end
     end


### PR DESCRIPTION
This would previously not fire on a module comparison.