### PR TITLE
Feature/update customer name validation

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
 
+0.1.12 / 2019-03-05
+==================
+
+  * Add Api::CustomerNameLengthError
+  * Update CustomerName model validation from 50 to 30 characters
+
 0.1.11 / 2019-02-28
 ==================
 

--- a/lib/snap.rb
+++ b/lib/snap.rb
@@ -6,6 +6,7 @@ require 'snap/version'
 require 'snap/client'
 require 'snap/response'
 
+require 'snap/api/errors/customer_name_length_error'
 require 'snap/api/errors/definition_error'
 require 'snap/api/errors/order_stage_error'
 require 'snap/api/errors/stock_total_not_found_error'

--- a/lib/snap/api/errors/customer_name_length_error.rb
+++ b/lib/snap/api/errors/customer_name_length_error.rb
@@ -1,0 +1,8 @@
+module Snap
+  module Api
+    # A definition error occurs when you attempt to create a shipment
+    # with a long customer name
+    class CustomerNameLengthError < StandardError
+    end
+  end
+end

--- a/lib/snap/client.rb
+++ b/lib/snap/client.rb
@@ -49,6 +49,7 @@ module Snap
       when 'Hash'
         raise Api::OrderStageError, httparty_response if httparty_response.parsed_response.value? 'ORDER_STAGE'
         raise Api::DefinitionError, httparty_response if httparty_response.parsed_response.value? 'DEFINITION'
+        raise Api::CustomerNameLengthError, httparty_response if httparty_response.parsed_response.value? 'LENGTH'
       end
     end
   end

--- a/lib/snap/models/shipment.rb
+++ b/lib/snap/models/shipment.rb
@@ -111,7 +111,7 @@ module Snap
       property :ShipContacts
       property :ShipmentDespatch
 
-      validates :CustomerName, length: { maximum: 50 }
+      validates :CustomerName, length: { maximum: 30 }, strict: Api::CustomerNameLengthError
     end
   end
 end

--- a/lib/snap/version.rb
+++ b/lib/snap/version.rb
@@ -1,3 +1,3 @@
 module Snap
-  VERSION = '0.1.11'.freeze
+  VERSION = '0.1.12'.freeze
 end


### PR DESCRIPTION
Update Shipment CustomerName model validation

Customer names with more than 30 characters are generating an error on
hydrate when shipments create method is called

```
=> {"K3K4EZ6NNL-CustomerName"=>"LENGTH",
"INA3374527-K3K4EZ6NNL"=>"LENGTH",
"K3K4EZ7QJD-ShipmentId"=>"SHIPMENT",
"INA3374527-K3K4EZ7QJD"=>"SHIPMENT",
"K3K4EZ7UJF-ShipmentId"=>"SHIPMENT",
"INA3374527-K3K4EZ7UJF"=>"SHIPMENT",
"K3K4EZ7Y5P-ShipmentId"=>"SHIPMENT",
"INA3374527-K3K4EZ7Y5P"=>"SHIPMENT",
"K3K4EZ8KCZ-ShipmentId"=>"SHIPMENT",
"INA3374527-K3K4EZ8KCZ"=>"SHIPMENT"}
```

This updates the CustomerName validation from 50 characters to 30

## Example

```
Snap::Models::Shipment.new(ShipmentId: 1, CustomerId: 1, DateDueOut: '11', CustomerName: 'FirstName LastName C/O More Content')
Snap::Api::CustomerNameLengthError: Customername is too long (maximum is 30 characters)
```